### PR TITLE
Adds support to APIs with multiple JSON mime type bodies

### DIFF
--- a/src/add-tests.coffee
+++ b/src/add-tests.coffee
@@ -6,19 +6,25 @@ Test = require './test'
 addTestIfNeeded = (tests, path, method, status, api) ->
     return unless api?.body
 
-    test = new Test
-
-    test.path = path
-    test.method = method
-    test.status = status
-
-    # Update test.request
-    if api.body['application/json']
-      test.example = api.body['application/json']?.example
-      test.schema = api.body['application/json']?.schema
-
-    # Append new test to tests
-    tests.push test
+    jsonMimeTypes = (mimeType for mimeType of api.body when mimeType.match(/application\/(.+\+)*json/))
+    if jsonMimeTypes.length == 0
+      test = new Test
+      test.path = path
+      test.method = method
+      test.status = status
+      # Add skipped test
+      tests.push test
+    else
+      for type in jsonMimeTypes
+        test = new Test
+        test.path = path
+        test.method = method
+        test.status = status
+        test.mimeType = type
+        test.example = api.body[type].example
+        test.schema = api.body[type].schema
+        # Append new test to tests
+        tests.push test
 
 
 # addTests(raml, tests, [parent], callback)

--- a/src/test.coffee
+++ b/src/test.coffee
@@ -11,14 +11,17 @@ class Test
     @path = ''
     @method = ''
     @status = 0
+    @mimeType = ''
     @schema = ''
     @example = ''
 
   name: ->
+    mimeInformation = ''
+    mimeInformation = " - #{@mimeType}" if @mimeType && @mimeType != ''
     if @status
-      "#{@method} response #{@status}"
+      "#{@method} response #{@status}#{mimeInformation}"
     else
-      "#{@method} request"
+      "#{@method} request#{mimeInformation}"
 
   skip: ->
     return false if @schema and @example

--- a/test/acceptance/cli-test.coffee
+++ b/test/acceptance/cli-test.coffee
@@ -69,13 +69,14 @@ describe "Command line interface", ->
         assert.equal exitStatus, 0
 
       it 'should print count of tests will run', ->
-        assert.equal 2, report.tests.length
+        assert.equal 3, report.tests.length
 
       it 'should print correct title for request', ->
-        assert.equal report.tests[0].fullTitle, '/songs POST request'
+        assert.equal report.tests[0].fullTitle, '/songs POST request - application/json'
+        assert.equal report.tests[1].fullTitle, '/songs POST request - application/hal+json'
 
       it 'should print correct title for response', ->
-        assert.equal report.tests[1].fullTitle, '/songs/{songId} GET response 200'
+        assert.equal report.tests[2].fullTitle, '/songs/{songId} GET response 200 - application/json'
 
     describe "when executing command with RAML contains csonschema", ->
 
@@ -108,7 +109,7 @@ describe "Command line interface", ->
           assert.equal report.stats.pending, 1
 
         it 'should failed on invalidated example', ->
-          assert.equal report.failures[0].fullTitle, '/songs/{songId} PUT response 200'
+          assert.equal report.failures[0].fullTitle, '/songs/{songId} PUT response 200 - application/json'
 
       describe 'contains multiple error', ->
         before (done) ->
@@ -126,9 +127,9 @@ describe "Command line interface", ->
           assert.equal report.stats.pending, 0
 
         it 'should failed on invalidated example', ->
-          assert.equal report.failures[0].fullTitle, '/songs/{songId} PUT request'
-          assert.equal report.failures[1].fullTitle, '/songs/search GET response 200'
-          assert.equal report.failures[2].fullTitle, '/songs/authors GET response 200'
+          assert.equal report.failures[0].fullTitle, '/songs/{songId} PUT request - application/json'
+          assert.equal report.failures[1].fullTitle, '/songs/search GET response 200 - application/json'
+          assert.equal report.failures[2].fullTitle, '/songs/authors GET response 200 - application/json'
 
 
     describe 'when executing command and RAML has defined mediaType in root section', ->

--- a/test/fixtures/song.raml
+++ b/test/fixtures/song.raml
@@ -30,6 +30,30 @@ traits:
           }
         example: |
           { "title": "A Beautiful Day", "artist": "Mike" }
+      application/hal+json:
+        schema: |
+          { "$schema": "http://json-schema.org/schema",
+            "type": "object",
+            "description": "A canonical song",
+            "properties": {
+              "_links": {
+                "type": "object",
+                "properties": {
+                  "self": {
+                    "type": "object",
+                    "properties": {
+                      "href": { "type": "string" }
+                    }
+                  }
+                }
+              },
+              "title":  { "type": "string" },
+              "artist": { "type": "string" }
+            },
+            "required": [ "_links", "title", "artist" ]
+          }
+        example: |
+          { "_links": { "self": { "href": "link-to-song" } }, "title": "A Beautiful Day", "artist": "Mike" }
 
   /{songId}:
     get:


### PR DESCRIPTION
- Anything matching application/*+json
- Adds the mime types to the tests title

Tests output:
```
$ ./bin/ramlev ./test/fixtures/song.raml


  /songs
    ✓ POST request - application/json
    ✓ POST request - application/hal+json

  /songs/{songId}
    ✓ GET response 200 - application/json


  3 passing (17ms)
```