### PR TITLE
Fix #27, update tests on iojs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 - '0.12'
 - '0.11'
 - '0.10'
+- 'iojs'
 env:
 - NODE_ENV=development
 notifications:

--- a/test/acceptance/cli-test.coffee
+++ b/test/acceptance/cli-test.coffee
@@ -42,7 +42,9 @@ describe "Command line interface", ->
       assert.equal exitStatus, 1
 
     it 'should print error message to stderr', ->
-      assert.include stderr, 'Error: ENOENT, open'
+      # See https://travis-ci.org/cybertk/ramlev/jobs/72294778#L231-L233
+      # iojs's behaviour is different from nodejs
+      assert.include stderr, 'Error: ENOENT'
 
   describe 'when called with arguments', ->
 


### PR DESCRIPTION
The error message of 'Cannot find specifed file' is different between and nodejs.

For iojs, it's

    cannot read foo.raml (Error: ENOENT: no such file or directory, open 'foo.raml'

For nodejs, it's

    cannot read foo.raml (Error: ENOENT, open 'foo.raml')