### PR TITLE
enable to require ramlev as normal npm module

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "ramlev": "bin/ramlev"
   },
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
+    "postinstall": "coffee -bc lib/*.coffee"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
this change makes ramlev enabled to be required like normal npm module.


after installing ramlev into some project locally, ramlev can be required from other .js files like following code.

```
npm install --save-dev ramlev
```


```javascript
var Ramlev = require('ramlev');
var ramlev = new Ramlev( config );
ramlev.run(function(.......){
  ......
});
```
